### PR TITLE
refator(charts): Add imagePullPolicy in charts for every experiment 

### DIFF
--- a/charts/kubernetes-chaos/templates/container-kill.yaml
+++ b/charts/kubernetes-chaos/templates/container-kill.yaml
@@ -35,6 +35,7 @@ spec:
           - "patch"
           - "delete"
     image: "{{ .Values.image.litmus.repository }}:{{ .Values.image.litmus.tag }}"
+    imagePullPolicy: {{ .Values.image.litmus.pullPolicy }}
     args:
     - -c
     - ansible-playbook ./experiments/generic/container_kill/container_kill_ansible_logic.yml -i /etc/ansible/hosts -vv; exit 0

--- a/charts/kubernetes-chaos/templates/disk-fill.yaml
+++ b/charts/kubernetes-chaos/templates/disk-fill.yaml
@@ -35,6 +35,7 @@ spec:
           - "update"
           - "delete"
     image: "{{ .Values.image.litmus.repository }}:{{ .Values.image.litmus.tag }}" 
+    imagePullPolicy: {{ .Values.image.litmus.pullPolicy }}
     args:
     - -c
     - ansible-playbook ./experiments/generic/disk_fill/disk_fill_ansible_logic.yml -i /etc/ansible/hosts -vv; exit 0

--- a/charts/kubernetes-chaos/templates/disk-loss.yaml
+++ b/charts/kubernetes-chaos/templates/disk-loss.yaml
@@ -34,6 +34,7 @@ spec:
           - "update"
           - "delete"
     image: "{{ .Values.image.litmus.repository }}:{{ .Values.image.litmus.tag }}"
+    imagePullPolicy: {{ .Values.image.litmus.pullPolicy }}
     args:
     - -c
     - ansible-playbook ./experiments/generic/disk_loss/disk_loss_ansible_logic.yml -i /etc/ansible/hosts -vv; exit 0

--- a/charts/kubernetes-chaos/templates/node-cpu-hog.yaml
+++ b/charts/kubernetes-chaos/templates/node-cpu-hog.yaml
@@ -41,6 +41,7 @@ spec:
           - "get"
           - "list"
     image: "{{ .Values.image.litmus.repository }}:{{ .Values.image.litmus.tag }}" 
+    imagePullPolicy: {{ .Values.image.litmus.pullPolicy }}
     args:
     - -c
     - ansible-playbook ./experiments/generic/node_cpu_hog/node_cpu_hog_ansible_logic.yml -i /etc/ansible/hosts -vv; exit 0

--- a/charts/kubernetes-chaos/templates/node-drain.yaml
+++ b/charts/kubernetes-chaos/templates/node-drain.yaml
@@ -45,6 +45,7 @@ spec:
           - "list"
           - "patch"
     image: "{{ .Values.image.litmus.repository }}:{{ .Values.image.litmus.tag }}" 
+    imagePullPolicy: {{ .Values.image.litmus.pullPolicy }}
     args:
     - -c
     - ansible-playbook ./experiments/generic/node_drain/node_drain_ansible_logic.yml -i /etc/ansible/hosts -vv; exit 0

--- a/charts/kubernetes-chaos/templates/node-memory-hog.yaml
+++ b/charts/kubernetes-chaos/templates/node-memory-hog.yaml
@@ -41,6 +41,7 @@ spec:
           - "get"
           - "list"
     image: "{{ .Values.image.litmus.repository }}:{{ .Values.image.litmus.tag }}"
+    imagePullPolicy: {{ .Values.image.litmus.pullPolicy }}
     args:
     - -c
     - ansible-playbook ./experiments/generic/node_memory_hog/node_memory_hog_ansible_logic.yml -i /etc/ansible/hosts -vv; exit 0

--- a/charts/kubernetes-chaos/templates/pod-cpu-hog.yaml
+++ b/charts/kubernetes-chaos/templates/pod-cpu-hog.yaml
@@ -33,6 +33,7 @@ spec:
           - "update"
           - "delete"
     image: "{{ .Values.image.litmus.repository }}:{{ .Values.image.litmus.tag }}"
+    imagePullPolicy: {{ .Values.image.litmus.pullPolicy }}
     args:
     - -c
     - ansible-playbook ./experiments/generic/pod_cpu_hog/pod_cpu_hog_ansible_logic.yml -i /etc/ansible/hosts -vv; exit 0

--- a/charts/kubernetes-chaos/templates/pod-delete.yaml
+++ b/charts/kubernetes-chaos/templates/pod-delete.yaml
@@ -43,6 +43,7 @@ spec:
           - "get"
           - "list"
     image: "{{ .Values.image.litmus.repository }}:{{ .Values.image.litmus.tag }}"
+    imagePullPolicy: {{ .Values.image.litmus.pullPolicy }}
     args:
     - -c
     - ansible-playbook ./experiments/generic/pod_delete/pod_delete_ansible_logic.yml -i /etc/ansible/hosts -vv; exit 0

--- a/charts/kubernetes-chaos/templates/pod-memory-hog.yaml
+++ b/charts/kubernetes-chaos/templates/pod-memory-hog.yaml
@@ -33,6 +33,7 @@ spec:
           - "update"
           - "delete"
     image: "{{ .Values.image.litmus.repository }}:{{ .Values.image.litmus.tag }}"
+    imagePullPolicy: {{ .Values.image.litmus.pullPolicy }}
     args:
     - -c
     - ansible-playbook ./experiments/generic/pod_memory_hog/pod_memory_hog_ansible_logic.yml -i /etc/ansible/hosts -vv; exit 0

--- a/charts/kubernetes-chaos/templates/pod-network-corruption.yaml
+++ b/charts/kubernetes-chaos/templates/pod-network-corruption.yaml
@@ -33,6 +33,7 @@ spec:
           - "update"
           - "get"
     image: "{{ .Values.image.litmus.repository }}:{{ .Values.image.litmus.tag }}" 
+    imagePullPolicy: {{ .Values.image.litmus.pullPolicy }}
     args:
     - -c
     - ansible-playbook ./experiments/generic/pod_network_corruption/pod_network_corruption_ansible_logic.yml -i /etc/ansible/hosts -vv; exit 0

--- a/charts/kubernetes-chaos/templates/pod-network-latency.yaml
+++ b/charts/kubernetes-chaos/templates/pod-network-latency.yaml
@@ -33,6 +33,7 @@ spec:
           - "update"
           - "delete"
     image: "{{ .Values.image.litmus.repository }}:{{ .Values.image.litmus.tag }}"
+    imagePullPolicy: {{ .Values.image.litmus.pullPolicy }}
     args:
     - -c
     - ansible-playbook ./experiments/generic/pod_network_latency/pod_network_latency_ansible_logic.yml -i /etc/ansible/hosts -vv; exit 0

--- a/charts/kubernetes-chaos/templates/pod-network-loss.yaml
+++ b/charts/kubernetes-chaos/templates/pod-network-loss.yaml
@@ -33,6 +33,7 @@ spec:
       - "update"
       - "delete"
     image: "{{ .Values.image.litmus.repository }}:{{ .Values.image.litmus.tag }}"
+    imagePullPolicy: {{ .Values.image.litmus.pullPolicy }}
     args:
     - -c
     - ansible-playbook ./experiments/generic/pod_network_loss/pod_network_loss_ansible_logic.yml -i /etc/ansible/hosts -vv; exit 0

--- a/charts/kubernetes-chaos/values.yaml
+++ b/charts/kubernetes-chaos/values.yaml
@@ -9,6 +9,7 @@ image:
   litmus: 
     repository: litmuschaos/ansible-runner
     tag: 1.4.0
+    pullPolicy: Always
 
   pumba:
     repository: gaiaadm/pumba
@@ -30,12 +31,6 @@ image:
     repository: litmuschaos/app-memory-stress
     tag: latest
 
-  linuxStressNG:
-    repository: alexeiled/stress-ng
-    tag: latest 
-
   litmusStressNG:
     repository: litmuschaos/stress-ng
     tag: latest 
-
-  

--- a/charts/kubernetes-chaos/values.yaml
+++ b/charts/kubernetes-chaos/values.yaml
@@ -31,6 +31,10 @@ image:
     repository: litmuschaos/app-memory-stress
     tag: latest
 
+  linuxStressNG:
+    repository: alexeiled/stress-ng
+    tag: latest 
+
   litmusStressNG:
     repository: litmuschaos/stress-ng
     tag: latest 


### PR DESCRIPTION
Signed-off-by: Udit Gaurav <udit.gaurav@mayadata.io>
- Makes image pull policy as tunable with a default value of Always in all chaos experiment charts.