### PR TITLE
fix(charts): Add lib and lib image values for pod-delete chart

### DIFF
--- a/charts/kubernetes-chaos/templates/container-kill.yaml
+++ b/charts/kubernetes-chaos/templates/container-kill.yaml
@@ -65,6 +65,11 @@ spec:
     - name: LIB
       value: 'pumba'
 
+    # provide the container runtime path for containerd
+    # applicable only for containerd runtime
+    - name: CONTAINER_PATH
+      value: '/run/containerd/containerd.sock'    
+
     # LIB_IMAGE can be - gaiaadm/pumba:0.6.5, gprasath/crictl:ci
     # For containerd image use: gprasath/crictl:ci
     - name: LIB_IMAGE  

--- a/charts/kubernetes-chaos/templates/pod-delete.yaml
+++ b/charts/kubernetes-chaos/templates/pod-delete.yaml
@@ -72,6 +72,10 @@ spec:
       value: '5'
 
     - name: LIB
-      value: ''    
+      value: 'litmus'
+
+    - name: LIB_IMAGE
+      value: "{{ .Values.image.litmusPodDeleteHelper.repository }}:{{ .Values.image.litmusPodDeleteHelper.tag }}" 
+
     labels:
       name: pod-delete

--- a/charts/kubernetes-chaos/values.yaml
+++ b/charts/kubernetes-chaos/values.yaml
@@ -8,7 +8,7 @@ fullnameOverride: "k8s"
 image:
   litmus: 
     repository: litmuschaos/ansible-runner
-    tag: 1.4.0
+    tag: 1.4.1
     pullPolicy: Always
 
   pumba:
@@ -38,3 +38,12 @@ image:
   litmusStressNG:
     repository: litmuschaos/stress-ng
     tag: latest 
+
+  litmusPodDeleteHelper:
+    repository: litmuschaos/pod-delete-helper
+    tag: latest
+
+  litmusContainerKillHelper:
+    repository: litmuschaos/container-kill-helper
+    tag: latest
+    


### PR DESCRIPTION
Signed-off-by: Udit Gaurav <uditgaurav@gmail.com>
- Add lib image values for the pod-delete experiment chart. This change was a part of litmus 1.4.1.